### PR TITLE
(GH-12) Add support for markdownlint-cli

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -16,7 +16,14 @@ BuildParameters.PrintParameters(Context);
 
 ToolSettings.SetToolSettings(
     context: Context,
-    dupFinderExcludePattern: new string[] { BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint.Tests/*.cs" },
+    dupFinderExcludePattern: new string[] 
+    { 
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint/Markdownlint/MarkdownlintIssuesSettings.cs",
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint/MarkdownlintCli/MarkdownlintCliIssuesSettings.cs",
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint.Tests/*.cs",
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint.Tests/Markdownlint/*.cs", 
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/*.cs" 
+    },
     testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues]* -[Cake.Issues.Testing]*",
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");

--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -74,9 +74,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MarkdownlintIssuesProviderFixture.cs" />
-    <Compile Include="MarkdownlintIssuesProviderTests.cs" />
-    <Compile Include="MarkdownlintIssuesSettingsTests.cs" />
+    <Compile Include="MarkdownlintCli\MarkdownlintCliIssuesProviderFixture.cs" />
+    <Compile Include="MarkdownlintCli\MarkdownlintCliIssuesProviderTests.cs" />
+    <Compile Include="MarkdownlintCli\MarkdownlintCliIssuesSettingsTests.cs" />
+    <Compile Include="Markdownlint\MarkdownlintIssuesProviderFixture.cs" />
+    <Compile Include="Markdownlint\MarkdownlintIssuesProviderTests.cs" />
+    <Compile Include="Markdownlint\MarkdownlintIssuesSettingsTests.cs" />
     <Compile Include="MarkdownlintRuleUrlResolverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -94,12 +97,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <EmbeddedResource Include="Testfiles\markdownlint-cli.log" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
     <Analyzer Include="..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesProviderFixture.cs
@@ -1,0 +1,48 @@
+﻿namespace Cake.Issues.Markdownlint.Tests.Markdownlint
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Cake.Issues.Markdownlint.Markdownlint;
+    using Cake.Testing;
+    using Core.Diagnostics;
+
+    internal class MarkdownlintIssuesProviderFixture
+    {
+        public MarkdownlintIssuesProviderFixture(string fileResourceName)
+        {
+            this.Log = new FakeLog { Verbosity = Verbosity.Normal };
+
+            using (var stream = this.GetType().Assembly.GetManifestResourceStream("Cake.Issues.Markdownlint.Tests.Testfiles." + fileResourceName))
+            {
+                using (var sr = new StreamReader(stream))
+                {
+                    this.Settings =
+                        MarkdownlintIssuesSettings.FromContent(
+                            sr.ReadToEnd());
+                }
+            }
+
+            this.RepositorySettings =
+                new RepositorySettings(@"c:\Source\Cake.Issues");
+        }
+
+        public FakeLog Log { get; set; }
+
+        public MarkdownlintIssuesSettings Settings { get; set; }
+
+        public RepositorySettings RepositorySettings { get; set; }
+
+        public MarkdownlintIssuesProvider Create()
+        {
+            var provider = new MarkdownlintIssuesProvider(this.Log, this.Settings);
+            provider.Initialize(this.RepositorySettings);
+            return provider;
+        }
+
+        public IEnumerable<IIssue> ReadIssues()
+        {
+            var issueProvider = this.Create();
+            return issueProvider.ReadIssues(IssueCommentFormat.PlainText);
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesProviderTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesProviderTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Cake.Issues.Markdownlint.Tests
+﻿namespace Cake.Issues.Markdownlint.Tests.Markdownlint
 {
     using System.Linq;
+    using Cake.Issues.Markdownlint.Markdownlint;
     using Cake.Testing;
     using Core.IO;
     using Shouldly;

--- a/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesSettingsTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/Markdownlint/MarkdownlintIssuesSettingsTests.cs
@@ -1,0 +1,125 @@
+﻿namespace Cake.Issues.Markdownlint.Tests.Markdownlint
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Cake.Issues.Markdownlint.Markdownlint;
+    using Shouldly;
+    using Testing;
+    using Xunit;
+
+    public sealed class MarkdownlintIssuesSettingsTests
+    {
+        public sealed class TheCtor
+        {
+            [Fact]
+            public void Should_Throw_If_LogFilePath_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() =>
+                    MarkdownlintIssuesSettings.FromFilePath(null));
+
+                // Then
+                result.IsArgumentNullException("logFilePath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LogFileContent_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() =>
+                    MarkdownlintIssuesSettings.FromContent(null));
+
+                // Then
+                result.IsArgumentNullException("logFileContent");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LogFileContent_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() =>
+                    MarkdownlintIssuesSettings.FromContent(string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("logFileContent");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LogFileContent_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() =>
+                    MarkdownlintIssuesSettings.FromContent(" "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("logFileContent");
+            }
+
+            [Fact]
+            public void Should_Set_Property_Values_Passed_To_Constructor()
+            {
+                // Given
+                const string logFileContent = "foo";
+
+                // When
+                var settings = MarkdownlintIssuesSettings.FromContent(logFileContent);
+
+                // Then
+                settings.LogFileContent.ShouldBe(logFileContent);
+            }
+
+            [Fact]
+            public void Should_Read_File_From_Disk()
+            {
+                var fileName = Path.GetTempFileName();
+                try
+                {
+                    // Given
+                    string expected;
+                    using (var ms = new MemoryStream())
+                    using (var stream = this.GetType().Assembly.GetManifestResourceStream("Cake.Issues.Markdownlint.Tests.Testfiles.markdownlint.json"))
+                    {
+                        stream.CopyTo(ms);
+                        var data = ms.ToArray();
+
+                        using (var file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+                        {
+                            file.Write(data, 0, data.Length);
+                        }
+
+                        expected = ConvertFromUtf8(data);
+                    }
+
+                    // When
+                    var settings =
+                        MarkdownlintIssuesSettings.FromFilePath(fileName);
+
+                    // Then
+                    settings.LogFileContent.ShouldBe(expected);
+                }
+                finally
+                {
+                    if (File.Exists(fileName))
+                    {
+                        File.Delete(fileName);
+                    }
+                }
+            }
+
+            private static string ConvertFromUtf8(byte[] bytes)
+            {
+                var enc = new UTF8Encoding(true);
+                var preamble = enc.GetPreamble();
+
+                if (preamble.Where((p, i) => p != bytes[i]).Any())
+                {
+                    throw new ArgumentException("Not utf8-BOM");
+                }
+
+                return enc.GetString(bytes.Skip(preamble.Length).ToArray());
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesProviderFixture.cs
@@ -1,13 +1,14 @@
-﻿namespace Cake.Issues.Markdownlint.Tests
+﻿namespace Cake.Issues.Markdownlint.Tests.MarkdownlintCli
 {
     using System.Collections.Generic;
     using System.IO;
+    using Cake.Issues.Markdownlint.MarkdownlintCli;
     using Cake.Testing;
     using Core.Diagnostics;
 
-    internal class MarkdownlintIssuesProviderFixture
+    internal class MarkdownlintCliIssuesProviderFixture
     {
-        public MarkdownlintIssuesProviderFixture(string fileResourceName)
+        public MarkdownlintCliIssuesProviderFixture(string fileResourceName)
         {
             this.Log = new FakeLog { Verbosity = Verbosity.Normal };
 
@@ -16,7 +17,7 @@
                 using (var sr = new StreamReader(stream))
                 {
                     this.Settings =
-                        MarkdownlintIssuesSettings.FromContent(
+                        MarkdownlintCliIssuesSettings.FromContent(
                             sr.ReadToEnd());
                 }
             }
@@ -27,13 +28,13 @@
 
         public FakeLog Log { get; set; }
 
-        public MarkdownlintIssuesSettings Settings { get; set; }
+        public MarkdownlintCliIssuesSettings Settings { get; set; }
 
         public RepositorySettings RepositorySettings { get; set; }
 
-        public MarkdownlintIssuesProvider Create()
+        public MarkdownlintCliIssuesProvider Create()
         {
-            var provider = new MarkdownlintIssuesProvider(this.Log, this.Settings);
+            var provider = new MarkdownlintCliIssuesProvider(this.Log, this.Settings);
             provider.Initialize(this.RepositorySettings);
             return provider;
         }

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesProviderTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesProviderTests.cs
@@ -1,0 +1,156 @@
+﻿namespace Cake.Issues.Markdownlint.Tests.MarkdownlintCli
+{
+    using System.Linq;
+    using Cake.Issues.Markdownlint.MarkdownlintCli;
+    using Cake.Testing;
+    using Core.IO;
+    using Shouldly;
+    using Testing;
+    using Xunit;
+
+    public sealed class MarkdownlintCliIssuesProviderTests
+    {
+        public sealed class TheCtor
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() =>
+                    new MarkdownlintCliIssuesProvider(
+                        null,
+                        MarkdownlintCliIssuesSettings.FromContent("Foo")));
+
+                // Then
+                result.IsArgumentNullException("log");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                var result = Record.Exception(() =>
+                    new MarkdownlintCliIssuesProvider(
+                        new FakeLog(),
+                        null));
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+        }
+
+        public sealed class TheReadIssuesMethod
+        {
+            [Fact]
+            public void Should_Read_Issue_Correct()
+            {
+                // Given
+                var fixture = new MarkdownlintCliIssuesProviderFixture("markdownlint-cli.log");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(8);
+                CheckIssue(
+                    issues[0],
+                    @"docs/index.md",
+                    1,
+                    "MD022",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022",
+                    0,
+                    "Headers should be surrounded by blank lines [Context: \"# foo\"]");
+                CheckIssue(
+                    issues[1],
+                    @"docs/index.md",
+                    2,
+                    "MD009",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009",
+                    0,
+                    "Trailing spaces [Expected: 2; Actual: 1]");
+                CheckIssue(
+                    issues[2],
+                    @"docs/index.md",
+                    2,
+                    "MD013",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013",
+                    0,
+                    "Line length [Expected: 100; Actual: 811]");
+                CheckIssue(
+                    issues[3],
+                    @"docs/index.md",
+                    4,
+                    "MD022",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022",
+                    0,
+                    "Headers should be surrounded by blank lines [Context: \"# bar\"]");
+                CheckIssue(
+                    issues[4],
+                    @"docs/index.md",
+                    4,
+                    "MD025",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025",
+                    0,
+                    "Multiple top level headers in the same document [Context: \"# bar\"]");
+                CheckIssue(
+                    issues[5],
+                    @"docs/index.md",
+                    5,
+                    "MD031",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md031",
+                    0,
+                    "Fenced code blocks should be surrounded by blank lines [Context: \"```\"]");
+                CheckIssue(
+                    issues[6],
+                    @"docs/index.md",
+                    5,
+                    "MD040",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040",
+                    0,
+                    "Fenced code blocks should have a language specified [Context: \"```\"]");
+                CheckIssue(
+                    issues[7],
+                    @"docs/index.md",
+                    6,
+                    "MD009",
+                    "https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009",
+                    0,
+                    "Trailing spaces [Expected: 2; Actual: 1]");
+            }
+
+            private static void CheckIssue(
+                IIssue issue,
+                string affectedFileRelativePath,
+                int? line,
+                string rule,
+                string ruleUrl,
+                int priority,
+                string message)
+            {
+                if (issue.AffectedFileRelativePath == null)
+                {
+                    affectedFileRelativePath.ShouldBeNull();
+                }
+                else
+                {
+                    issue.AffectedFileRelativePath.ToString().ShouldBe(new FilePath(affectedFileRelativePath).ToString());
+                    issue.AffectedFileRelativePath.IsRelative.ShouldBe(true, "Issue path is not relative");
+                }
+
+                issue.Line.ShouldBe(line);
+                issue.Rule.ShouldBe(rule);
+
+                if (issue.RuleUrl == null)
+                {
+                    ruleUrl.ShouldBeNull();
+                }
+                else
+                {
+                    issue.RuleUrl.ToString().ShouldBe(ruleUrl);
+                }
+
+                issue.Priority.ShouldBe(priority);
+                issue.Message.ShouldBe(message);
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesSettingsTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintCli/MarkdownlintCliIssuesSettingsTests.cs
@@ -1,14 +1,15 @@
-﻿namespace Cake.Issues.Markdownlint.Tests
+﻿namespace Cake.Issues.Markdownlint.Tests.MarkdownlintCli
 {
     using System;
     using System.IO;
     using System.Linq;
     using System.Text;
+    using Cake.Issues.Markdownlint.MarkdownlintCli;
     using Shouldly;
     using Testing;
     using Xunit;
 
-    public sealed class MarkdownlintIssuesSettingsTests
+    public sealed class MarkdownlintCliIssuesSettingsTests
     {
         public sealed class TheCtor
         {
@@ -17,7 +18,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    MarkdownlintIssuesSettings.FromFilePath(null));
+                    MarkdownlintCliIssuesSettings.FromFilePath(null));
 
                 // Then
                 result.IsArgumentNullException("logFilePath");
@@ -28,7 +29,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    MarkdownlintIssuesSettings.FromContent(null));
+                    MarkdownlintCliIssuesSettings.FromContent(null));
 
                 // Then
                 result.IsArgumentNullException("logFileContent");
@@ -39,7 +40,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    MarkdownlintIssuesSettings.FromContent(string.Empty));
+                    MarkdownlintCliIssuesSettings.FromContent(string.Empty));
 
                 // Then
                 result.IsArgumentOutOfRangeException("logFileContent");
@@ -50,7 +51,7 @@
             {
                 // Given / When
                 var result = Record.Exception(() =>
-                    MarkdownlintIssuesSettings.FromContent(" "));
+                    MarkdownlintCliIssuesSettings.FromContent(" "));
 
                 // Then
                 result.IsArgumentOutOfRangeException("logFileContent");
@@ -63,7 +64,7 @@
                 const string logFileContent = "foo";
 
                 // When
-                var settings = MarkdownlintIssuesSettings.FromContent(logFileContent);
+                var settings = MarkdownlintCliIssuesSettings.FromContent(logFileContent);
 
                 // Then
                 settings.LogFileContent.ShouldBe(logFileContent);
@@ -78,7 +79,7 @@
                     // Given
                     string expected;
                     using (var ms = new MemoryStream())
-                    using (var stream = this.GetType().Assembly.GetManifestResourceStream("Cake.Issues.Markdownlint.Tests.Testfiles.markdownlint.json"))
+                    using (var stream = this.GetType().Assembly.GetManifestResourceStream("Cake.Issues.Markdownlint.Tests.Testfiles.markdownlint-cli.log"))
                     {
                         stream.CopyTo(ms);
                         var data = ms.ToArray();
@@ -88,12 +89,12 @@
                             file.Write(data, 0, data.Length);
                         }
 
-                        expected = ConvertFromUtf8(data);
+                        expected = Encoding.UTF8.GetString(data);
                     }
 
                     // When
                     var settings =
-                        MarkdownlintIssuesSettings.FromFilePath(fileName);
+                        MarkdownlintCliIssuesSettings.FromFilePath(fileName);
 
                     // Then
                     settings.LogFileContent.ShouldBe(expected);
@@ -105,19 +106,6 @@
                         File.Delete(fileName);
                     }
                 }
-            }
-
-            private static string ConvertFromUtf8(byte[] bytes)
-            {
-                var enc = new UTF8Encoding(true);
-                var preamble = enc.GetPreamble();
-
-                if (preamble.Where((p, i) => p != bytes[i]).Any())
-                {
-                    throw new ArgumentException("Not utf8-BOM");
-                }
-
-                return enc.GetString(bytes.Skip(preamble.Length).ToArray());
             }
         }
     }

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/markdownlint-cli.log
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/markdownlint-cli.log
@@ -1,0 +1,8 @@
+C:/Git/Test/Cake.Prca/docs/index.md: 1: MD022/blanks-around-headers Headers should be surrounded by blank lines [Context: "# foo"]
+C:/Git/Test/Cake.Prca/docs/index.md: 2: MD009/no-trailing-spaces Trailing spaces [Expected: 2; Actual: 1]
+C:/Git/Test/Cake.Prca/docs/index.md: 2: MD013/line-length Line length [Expected: 100; Actual: 811]
+C:/Git/Test/Cake.Prca/docs/index.md: 4: MD022/blanks-around-headers Headers should be surrounded by blank lines [Context: "# bar"]
+C:/Git/Test/Cake.Prca/docs/index.md: 4: MD025/single-h1 Multiple top level headers in the same document [Context: "# bar"]
+C:/Git/Test/Cake.Prca/docs/index.md: 5: MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
+C:/Git/Test/Cake.Prca/docs/index.md: 5: MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
+C:/Git/Test/Cake.Prca/docs/index.md: 6: MD009/no-trailing-spaces Trailing spaces [Expected: 2; Actual: 1]

--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -61,8 +61,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MarkdownlintIssuesAliases.cs" />
-    <Compile Include="MarkdownlintIssuesProvider.cs" />
-    <Compile Include="MarkdownlintIssuesSettings.cs" />
+    <Compile Include="MarkdownlintCli\MarkdownlintCliIssuesProvider.cs" />
+    <Compile Include="MarkdownlintCli\MarkdownlintCliIssuesSettings.cs" />
+    <Compile Include="MarkdownlintIssuesAliases.MarkdownlintCli.cs" />
+    <Compile Include="MarkdownlintIssuesAliases.Markdownlint.cs" />
+    <Compile Include="Markdownlint\MarkdownlintIssuesProvider.cs" />
+    <Compile Include="Markdownlint\MarkdownlintIssuesSettings.cs" />
     <Compile Include="MarkdownlintRuleUrlResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -78,6 +82,7 @@
     <Analyzer Include="..\packages\System.Security.Cryptography.Hashing.Algorithms.Analyzers.1.1.0\analyzers\dotnet\cs\System.Security.Cryptography.Hashing.Algorithms.Analyzers.dll" />
     <Analyzer Include="..\packages\System.Security.Cryptography.Hashing.Algorithms.Analyzers.1.1.0\analyzers\dotnet\cs\System.Security.Cryptography.Hashing.Algorithms.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Cake.Issues.Markdownlint/Markdownlint/MarkdownlintIssuesProvider.cs
+++ b/src/Cake.Issues.Markdownlint/Markdownlint/MarkdownlintIssuesProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Cake.Issues.Markdownlint
+﻿namespace Cake.Issues.Markdownlint.Markdownlint
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Cake.Issues.Markdownlint/Markdownlint/MarkdownlintIssuesSettings.cs
+++ b/src/Cake.Issues.Markdownlint/Markdownlint/MarkdownlintIssuesSettings.cs
@@ -1,0 +1,65 @@
+﻿namespace Cake.Issues.Markdownlint.Markdownlint
+{
+    using System.IO;
+    using Core.IO;
+
+    /// <summary>
+    /// Settings for <see cref="MarkdownlintIssuesAliases"/>.
+    /// </summary>
+    public class MarkdownlintIssuesSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownlintIssuesSettings"/> class.
+        /// </summary>
+        /// <param name="logFilePath">Path to the the Markdownlint log file.</param>
+        protected MarkdownlintIssuesSettings(FilePath logFilePath)
+        {
+            logFilePath.NotNull(nameof(logFilePath));
+
+            using (var stream = new FileStream(logFilePath.FullPath, FileMode.Open, FileAccess.Read))
+            {
+                using (var sr = new StreamReader(stream))
+                {
+                    this.LogFileContent = sr.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownlintIssuesSettings"/> class.
+        /// </summary>
+        /// <param name="logFileContent">Content of the the Markdownlint log file.</param>
+        protected MarkdownlintIssuesSettings(string logFileContent)
+        {
+            logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
+
+            this.LogFileContent = logFileContent;
+        }
+
+        /// <summary>
+        /// Gets the content of the log file.
+        /// </summary>
+        public string LogFileContent { get; private set; }
+
+        /// <summary>
+        /// Returns a new instance of the <see cref="MarkdownlintIssuesSettings"/> class from a log file on disk.
+        /// </summary>
+        /// <param name="logFilePath">Path to the Markdownlint log file.</param>
+        /// <returns>Instance of the <see cref="MarkdownlintIssuesSettings"/> class.</returns>
+        public static MarkdownlintIssuesSettings FromFilePath(FilePath logFilePath)
+        {
+            return new MarkdownlintIssuesSettings(logFilePath);
+        }
+
+        /// <summary>
+        /// Returns a new instance of the <see cref="MarkdownlintIssuesSettings"/> class from the content
+        /// of a Markdownlint log file.
+        /// </summary>
+        /// <param name="logFileContent">Content of the Markdownlint log file.</param>
+        /// <returns>Instance of the <see cref="MarkdownlintIssuesSettings"/> class.</returns>
+        public static MarkdownlintIssuesSettings FromContent(string logFileContent)
+        {
+            return new MarkdownlintIssuesSettings(logFileContent);
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint/MarkdownlintCli/MarkdownlintCliIssuesProvider.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintCli/MarkdownlintCliIssuesProvider.cs
@@ -1,0 +1,86 @@
+﻿namespace Cake.Issues.Markdownlint.MarkdownlintCli
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Core.Diagnostics;
+
+    /// <summary>
+    /// Provider for issues reported by markdownlint-cli.
+    /// </summary>
+    internal class MarkdownlintCliIssuesProvider : IssueProvider
+    {
+        private readonly MarkdownlintCliIssuesSettings settings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownlintCliIssuesProvider"/> class.
+        /// </summary>
+        /// <param name="log">The Cake log context.</param>
+        /// <param name="settings">Settings for reading the log file.</param>
+        public MarkdownlintCliIssuesProvider(ICakeLog log, MarkdownlintCliIssuesSettings settings)
+            : base(log)
+        {
+            settings.NotNull(nameof(settings));
+
+            this.settings = settings;
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<IIssue> InternalReadIssues(IssueCommentFormat format)
+        {
+            var regex = new Regex(@"(.*): (\d*): (MD\d*)/((?:\w*-*)*) (.*)");
+
+            foreach (var line in this.settings.LogFileContent.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList().Where(s => !string.IsNullOrEmpty(s)))
+            {
+                var groups = regex.Match(line).Groups;
+
+                // Read affected file from the line.
+                if (!this.TryGetFile(groups, this.Settings, out string fileName))
+                {
+                    continue;
+                }
+
+                var lineNumber = int.Parse(groups[2].Value);
+                var rule = groups[3].Value;
+                var ruleDescription = groups[5].Value;
+
+                yield return
+                    new Issue<MarkdownlintCliIssuesProvider>(
+                        fileName,
+                        lineNumber,
+                        ruleDescription,
+                        0,
+                        rule,
+                        MarkdownlintRuleUrlResolver.Instance.ResolveRuleUrl(rule));
+            }
+        }
+
+        /// <summary>
+        /// Reads the affected file path from a parsed entry.
+        /// </summary>
+        /// <param name="values">Parsed values of a line in the log file.</param>
+        /// <param name="repositorySettings">Repository settings to use.</param>
+        /// <param name="fileName">Returns the full path to the affected file.</param>
+        /// <returns>True if the file path could be parsed.</returns>
+        private bool TryGetFile(
+            GroupCollection values,
+            RepositorySettings repositorySettings,
+            out string fileName)
+        {
+            fileName = values[1].Value;
+
+            // Make path relative to repository root.
+            fileName = fileName.Substring(repositorySettings.RepositoryRoot.FullPath.Length);
+
+            // Remove leading directory separator.
+            if (fileName.StartsWith("/"))
+            {
+                fileName = fileName.Substring(1);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint/MarkdownlintCli/MarkdownlintCliIssuesSettings.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintCli/MarkdownlintCliIssuesSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Cake.Issues.Markdownlint
+﻿namespace Cake.Issues.Markdownlint.MarkdownlintCli
 {
     using System.IO;
     using Core.IO;
@@ -6,13 +6,13 @@
     /// <summary>
     /// Settings for <see cref="MarkdownlintIssuesAliases"/>.
     /// </summary>
-    public class MarkdownlintIssuesSettings
+    public class MarkdownlintCliIssuesSettings
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MarkdownlintIssuesSettings"/> class.
+        /// Initializes a new instance of the <see cref="MarkdownlintCliIssuesSettings"/> class.
         /// </summary>
         /// <param name="logFilePath">Path to the the Markdownlint log file.</param>
-        protected MarkdownlintIssuesSettings(FilePath logFilePath)
+        protected MarkdownlintCliIssuesSettings(FilePath logFilePath)
         {
             logFilePath.NotNull(nameof(logFilePath));
 
@@ -26,10 +26,10 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MarkdownlintIssuesSettings"/> class.
+        /// Initializes a new instance of the <see cref="MarkdownlintCliIssuesSettings"/> class.
         /// </summary>
         /// <param name="logFileContent">Content of the the Markdownlint log file.</param>
-        protected MarkdownlintIssuesSettings(string logFileContent)
+        protected MarkdownlintCliIssuesSettings(string logFileContent)
         {
             logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
 
@@ -42,24 +42,24 @@
         public string LogFileContent { get; private set; }
 
         /// <summary>
-        /// Returns a new instance of the <see cref="MarkdownlintIssuesSettings"/> class from a log file on disk.
+        /// Returns a new instance of the <see cref="MarkdownlintCliIssuesSettings"/> class from a log file on disk.
         /// </summary>
         /// <param name="logFilePath">Path to the Markdownlint log file.</param>
-        /// <returns>Instance of the <see cref="MarkdownlintIssuesSettings"/> class.</returns>
-        public static MarkdownlintIssuesSettings FromFilePath(FilePath logFilePath)
+        /// <returns>Instance of the <see cref="MarkdownlintCliIssuesSettings"/> class.</returns>
+        public static MarkdownlintCliIssuesSettings FromFilePath(FilePath logFilePath)
         {
-            return new MarkdownlintIssuesSettings(logFilePath);
+            return new MarkdownlintCliIssuesSettings(logFilePath);
         }
 
         /// <summary>
-        /// Returns a new instance of the <see cref="MarkdownlintIssuesSettings"/> class from the content
+        /// Returns a new instance of the <see cref="MarkdownlintCliIssuesSettings"/> class from the content
         /// of a Markdownlint log file.
         /// </summary>
         /// <param name="logFileContent">Content of the Markdownlint log file.</param>
-        /// <returns>Instance of the <see cref="MarkdownlintIssuesSettings"/> class.</returns>
-        public static MarkdownlintIssuesSettings FromContent(string logFileContent)
+        /// <returns>Instance of the <see cref="MarkdownlintCliIssuesSettings"/> class.</returns>
+        public static MarkdownlintCliIssuesSettings FromContent(string logFileContent)
         {
-            return new MarkdownlintIssuesSettings(logFileContent);
+            return new MarkdownlintCliIssuesSettings(logFileContent);
         }
     }
 }

--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.Markdownlint.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.Markdownlint.cs
@@ -1,0 +1,122 @@
+﻿namespace Cake.Issues.Markdownlint
+{
+    using Cake.Issues.Markdownlint.Markdownlint;
+    using Core;
+    using Core.Annotations;
+    using Core.IO;
+
+#pragma warning disable SA1601 // Partial elements must be documented
+    public static partial class MarkdownlintIssuesAliases
+#pragma warning restore SA1601 // Partial elements must be documented
+    {
+        /// <summary>
+        /// Gets the name of the Markdownlint issue provider.
+        /// This name can be used to identify issues based on the <see cref="IIssue.ProviderType"/> property.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>Name of the Markdownlint issue provider.</returns>
+        [CakePropertyAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.Markdownlint")]
+        public static string MarkdownlintIssuesProviderTypeName(
+            this ICakeContext context)
+        {
+            context.NotNull(nameof(context));
+
+            return Issue<MarkdownlintIssuesProvider>.GetProviderTypeName();
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by Markdownlint using a log file from disk.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFilePath">Path to the the Markdownlint log file.</param>
+        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
+        /// <example>
+        /// <para>Read issues reported by Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintIssuesFromFilePath(@"c:\build\Markdownlint.log"),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.Markdownlint")]
+        public static IIssueProvider MarkdownlintIssuesFromFilePath(
+            this ICakeContext context,
+            FilePath logFilePath)
+        {
+            context.NotNull(nameof(context));
+            logFilePath.NotNull(nameof(logFilePath));
+
+            return context.MarkdownlintIssues(MarkdownlintIssuesSettings.FromFilePath(logFilePath));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by Markdownlint using log file content.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFileContent">Content of the the Markdownlint log file.</param>
+        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
+        /// <example>
+        /// <para>Read issues reported by Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintIssuesFromContent(logFileContent),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.Markdownlint")]
+        public static IIssueProvider MarkdownlintIssuesFromContent(
+            this ICakeContext context,
+            string logFileContent)
+        {
+            context.NotNull(nameof(context));
+            logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
+
+            return context.MarkdownlintIssues(MarkdownlintIssuesSettings.FromContent(logFileContent));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by Markdownlint using specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">Settings for reading the Markdownlint log.</param>
+        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
+        /// <example>
+        /// <para>Read issues reported by Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var settings =
+        ///         new MarkdownlintIssuesSettings("C:\build\Markdownlint.log");
+        ///
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintIssuesFromFilePath(settings),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.Markdownlint")]
+        public static IIssueProvider MarkdownlintIssues(
+            this ICakeContext context,
+            MarkdownlintIssuesSettings settings)
+        {
+            context.NotNull(nameof(context));
+            settings.NotNull(nameof(settings));
+
+            return new MarkdownlintIssuesProvider(context.Log, settings);
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.MarkdownlintCli.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.MarkdownlintCli.cs
@@ -1,0 +1,125 @@
+﻿namespace Cake.Issues.Markdownlint
+{
+    using Cake.Issues.Markdownlint.MarkdownlintCli;
+    using Core;
+    using Core.Annotations;
+    using Core.IO;
+
+#pragma warning disable SA1601 // Partial elements must be documented
+    public static partial class MarkdownlintIssuesAliases
+#pragma warning restore SA1601 // Partial elements must be documented
+    {
+        /// <summary>
+        /// Gets the name of the markdownlint-cli issue provider.
+        /// This name can be used to identify issues based on the <see cref="IIssue.ProviderType"/> property.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>Name of the markdownlint-cli issue provider.</returns>
+        [CakePropertyAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.MarkdownlintCli")]
+        public static string MarkdownlintCliIssuesProviderTypeName(
+            this ICakeContext context)
+        {
+            context.NotNull(nameof(context));
+
+            return Issue<MarkdownlintCliIssuesProvider>.GetProviderTypeName();
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by markdownlint-cli or Cake.Markdownlint
+        /// using a log file from disk.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFilePath">Path to the the markdownlint-cli log file.</param>
+        /// <returns>Instance of a provider for issues reported by markdownlint-cli.</returns>
+        /// <example>
+        /// <para>Read issues reported by markdownlint-cli or Cake.Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintCliIssuesFromFilePath(@"c:\build\Markdownlint.log"),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.MarkdownlintCli")]
+        public static IIssueProvider MarkdownlintCliIssuesFromFilePath(
+            this ICakeContext context,
+            FilePath logFilePath)
+        {
+            context.NotNull(nameof(context));
+            logFilePath.NotNull(nameof(logFilePath));
+
+            return context.MarkdownlintCliIssues(MarkdownlintCliIssuesSettings.FromFilePath(logFilePath));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by markdownlint-cli or Cake.Markdownlint
+        /// using log file content.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="logFileContent">Content of the the markdownlint-cli log file.</param>
+        /// <returns>Instance of a provider for issues reported by markdownlint-cli.</returns>
+        /// <example>
+        /// <para>Read issues reported by markdownlint-cli or Cake.Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintCliIssuesFromContent(logFileContent),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.MarkdownlintCli")]
+        public static IIssueProvider MarkdownlintCliIssuesFromContent(
+            this ICakeContext context,
+            string logFileContent)
+        {
+            context.NotNull(nameof(context));
+            logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
+
+            return context.MarkdownlintCliIssues(MarkdownlintCliIssuesSettings.FromContent(logFileContent));
+        }
+
+        /// <summary>
+        /// Gets an instance of a provider for issues reported by markdownlint-cli or Cake.Markdownlint
+        /// using specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">Settings for reading the markdownlint-cli log.</param>
+        /// <returns>Instance of a provider for issues reported by markdownlint-cli.</returns>
+        /// <example>
+        /// <para>Read issues reported by markdownlint-cli or Cake.Markdownlint:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var settings =
+        ///         new MarkdownlintCliIssuesSettings("C:\build\Markdownlint.log");
+        ///
+        ///     var issues =
+        ///         ReadIssues(
+        ///             MarkdownlintCliIssuesFromFilePath(settings),
+        ///             @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        [CakeNamespaceImport("Cake.Issues.Markdownlint.MarkdownlintCli")]
+        public static IIssueProvider MarkdownlintCliIssues(
+            this ICakeContext context,
+            MarkdownlintCliIssuesSettings settings)
+        {
+            context.NotNull(nameof(context));
+            settings.NotNull(nameof(settings));
+
+            return new MarkdownlintCliIssuesProvider(context.Log, settings);
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.cs
@@ -1,119 +1,12 @@
 ﻿namespace Cake.Issues.Markdownlint
 {
-    using Core;
     using Core.Annotations;
-    using Core.IO;
 
     /// <summary>
     /// Contains functionality for reading issues from Markdownlint log files.
     /// </summary>
     [CakeAliasCategory(IssuesAliasConstants.MainCakeAliasCategory)]
-    public static class MarkdownlintIssuesAliases
+    public static partial class MarkdownlintIssuesAliases
     {
-        /// <summary>
-        /// Gets the name of the Markdownlint issue provider.
-        /// This name can be used to identify issues based on the <see cref="IIssue.ProviderType"/> property.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <returns>Name of the Markdownlint issue provider.</returns>
-        [CakePropertyAlias]
-        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
-        public static string MarkdownlintIssuesProviderTypeName(
-            this ICakeContext context)
-        {
-            context.NotNull(nameof(context));
-
-            return Issue<MarkdownlintIssuesProvider>.GetProviderTypeName();
-        }
-
-        /// <summary>
-        /// Gets an instance of a provider for issues reported by Markdownlint using a log file from disk.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="logFilePath">Path to the the Markdownlint log file.</param>
-        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
-        /// <example>
-        /// <para>Read issues reported by Markdownlint:</para>
-        /// <code>
-        /// <![CDATA[
-        ///     var issues =
-        ///         ReadIssues(
-        ///             MarkdownlintIssuesFromFilePath(@"c:\build\Markdownlint.log"),
-        ///             @"c:\repo");
-        /// ]]>
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
-        public static IIssueProvider MarkdownlintIssuesFromFilePath(
-            this ICakeContext context,
-            FilePath logFilePath)
-        {
-            context.NotNull(nameof(context));
-            logFilePath.NotNull(nameof(logFilePath));
-
-            return context.MarkdownlintIssues(MarkdownlintIssuesSettings.FromFilePath(logFilePath));
-        }
-
-        /// <summary>
-        /// Gets an instance of a provider for issues reported by Markdownlint using log file content.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="logFileContent">Content of the the Markdownlint log file.</param>
-        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
-        /// <example>
-        /// <para>Read issues reported by Markdownlint:</para>
-        /// <code>
-        /// <![CDATA[
-        ///     var issues =
-        ///         ReadIssues(
-        ///             MarkdownlintIssuesFromContent(logFileContent),
-        ///             @"c:\repo");
-        /// ]]>
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
-        public static IIssueProvider MarkdownlintIssuesFromContent(
-            this ICakeContext context,
-            string logFileContent)
-        {
-            context.NotNull(nameof(context));
-            logFileContent.NotNullOrWhiteSpace(nameof(logFileContent));
-
-            return context.MarkdownlintIssues(MarkdownlintIssuesSettings.FromContent(logFileContent));
-        }
-
-        /// <summary>
-        /// Gets an instance of a provider for issues reported by Markdownlint using specified settings.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="settings">Settings for reading the Markdownlint log.</param>
-        /// <returns>Instance of a provider for issues reported by Markdownlint.</returns>
-        /// <example>
-        /// <para>Read issues reported by Markdownlint:</para>
-        /// <code>
-        /// <![CDATA[
-        ///     var settings =
-        ///         new MarkdownlintIssuesSettings("C:\build\Markdownlint.log");
-        ///
-        ///     var issues =
-        ///         ReadIssues(
-        ///             MarkdownlintIssuesFromFilePath(settings),
-        ///             @"c:\repo");
-        /// ]]>
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
-        public static IIssueProvider MarkdownlintIssues(
-            this ICakeContext context,
-            MarkdownlintIssuesSettings settings)
-        {
-            context.NotNull(nameof(context));
-            settings.NotNull(nameof(settings));
-
-            return new MarkdownlintIssuesProvider(context.Log, settings);
-        }
     }
 }


### PR DESCRIPTION
Add support for markdownlint-cli including output provided by Cake.Markdownlint addin.

Fixes #12