### PR TITLE
Remove NuGet package caching from AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,5 +27,4 @@ branches:
 #  Build Cache                    #
 #---------------------------------#
 cache:
-- src\packages -> src\**\packages.config
 - tools -> setup.cake


### PR DESCRIPTION
Remove NuGet package caching from AppVeyor build