### PR TITLE
Isolate rule URL resolver instance in test cases

### DIFF
--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintRuleUrlResolverTests.cs
@@ -79,7 +79,7 @@
                 const string fooUrl = "http://foo.com/";
                 const string bar = "MD456";
                 const string barUrl = "http://bar.com/";
-                var urlResolver = MarkdownlintRuleUrlResolver.Instance;
+                var urlResolver = new MarkdownlintRuleUrlResolver();
                 urlResolver.AddUrlResolver(x => x.Rule == foo ? new Uri(fooUrl) : null, 1);
                 urlResolver.AddUrlResolver(x => x.Rule == bar ? new Uri(barUrl) : null, 1);
 
@@ -98,7 +98,7 @@
             {
                 // Given
                 int? ruleId = null;
-                var urlResolver = MarkdownlintRuleUrlResolver.Instance;
+                var urlResolver = new MarkdownlintRuleUrlResolver();
                 urlResolver.AddUrlResolver(
                     x =>
                     {

--- a/src/Cake.Issues.Markdownlint/MarkdownlintRuleUrlResolver.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintRuleUrlResolver.cs
@@ -14,7 +14,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownlintRuleUrlResolver"/> class.
         /// </summary>
-        private MarkdownlintRuleUrlResolver()
+        internal MarkdownlintRuleUrlResolver()
         {
             this.AddUrlResolver(x =>
                 new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#" + x.Rule.ToLowerInvariant()));


### PR DESCRIPTION
Tests from each test class are run in parallel. The tests in `MarkdownlintRuleUrlResolverTests.TheResolveRuleUrlMethod` which register an URL resolver have side effects. Especially the test case `MarkdownlintRuleUrlResolverTests.TheResolveRuleUrlMethod.Should_Parse_RuleId` is influenced by other tests run in parallel which can lead to the test failing.

This PR changes these tests to have its own instance of `MarkdownlintRuleUrlResolver`.