### PR TITLE
(GH-104) Support markdownlint-cli 0.22.0

### DIFF
--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -17,9 +17,13 @@
     <CodeAnalysisRuleSet>..\Cake.Issues.Markdownlint.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Testfiles\MarkdownlintCliLogFileFormat\markdownlint-cli-0.22.0.log" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Cake.Issues.Markdownlint\Cake.Issues.Markdownlint.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliLogFileFormat\markdownlint-cli-0.22.0.log" />
     <EmbeddedResource Include="Testfiles\MarkdownlintLogFileFormat\markdownlint.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
@@ -304,6 +304,101 @@
                         .OfRule("MD047", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047"))
                         .WithPriority(IssuePriority.Warning));
             }
+
+            [Fact]
+            public void Should_Read_Issue_Correct_0_22_0()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.22.0.log");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(9);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                        "Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: \"# foo\"]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 1)
+                        .OfRule("MD022", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[1],
+                    IssueBuilder.NewIssue(
+                        "Trailing spaces [Expected: 0 or 2; Actual: 1]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 2)
+                        .OfRule("MD009", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[2],
+                    IssueBuilder.NewIssue(
+                        "Line length [Expected: 100; Actual: 811]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 2)
+                        .OfRule("MD013", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[3],
+                    IssueBuilder.NewIssue(
+                        "Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: \"# bar\"]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 4)
+                        .OfRule("MD022", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[4],
+                    IssueBuilder.NewIssue(
+                        "Multiple top level headings in the same document [Context: \"# bar\"]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 4)
+                        .OfRule("MD025", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[5],
+                    IssueBuilder.NewIssue(
+                        "Fenced code blocks should be surrounded by blank lines [Context: \"```\"]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 5)
+                        .OfRule("MD031", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md031"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[6],
+                    IssueBuilder.NewIssue(
+                        "Fenced code blocks should have a language specified [Context: \"```\"]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 5)
+                        .OfRule("MD040", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[7],
+                    IssueBuilder.NewIssue(
+                        "Trailing spaces [Expected: 0 or 2; Actual: 1]",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 6)
+                        .OfRule("MD009", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[8],
+                    IssueBuilder.NewIssue(
+                        "Files should end with a single newline character",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/index.md", 7)
+                        .OfRule("MD047", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047"))
+                        .WithPriority(IssuePriority.Warning));
+            }
         }
     }
 }

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliLogFileFormat/markdownlint-cli-0.22.0.log
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliLogFileFormat/markdownlint-cli-0.22.0.log
@@ -1,0 +1,9 @@
+C:/Git/Test/Cake.Prca/docs/index.md:1 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# foo"]
+C:/Git/Test/Cake.Prca/docs/index.md:2:811 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
+C:/Git/Test/Cake.Prca/docs/index.md:2:101 MD013/line-length Line length [Expected: 100; Actual: 811]
+C:/Git/Test/Cake.Prca/docs/index.md:4 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# bar"]
+C:/Git/Test/Cake.Prca/docs/index.md:4 MD025/single-title/single-h1 Multiple top level headings in the same document [Context: "# bar"]
+C:/Git/Test/Cake.Prca/docs/index.md:5 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
+C:/Git/Test/Cake.Prca/docs/index.md:5 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
+C:/Git/Test/Cake.Prca/docs/index.md:6:840 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
+C:/Git/Test/Cake.Prca/docs/index.md:7:3 MD047/single-trailing-newline Files should end with a single newline character

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
@@ -30,7 +30,7 @@
             repositorySettings.NotNull(nameof(repositorySettings));
             markdownlintIssuesSettings.NotNull(nameof(markdownlintIssuesSettings));
 
-            var regex = new Regex(@"(?<filePath>.*): ?(?<lineNumber>\d+):? (?<ruleId>MD\d+)/(?<ruleName>(?:\w*-*/*)*) (?<message>.*)");
+            var regex = new Regex(@"(?<filePath>.*[^:\d+]): ?(?<lineNumber>\d+):?(?<columnNumber>\d+)? (?<ruleId>MD\d+)/(?<ruleName>(?:\w*-*/*)*) (?<message>.*)");
 
             foreach (var line in markdownlintIssuesSettings.LogFileContent.ToStringUsingEncoding().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList().Where(s => !string.IsNullOrEmpty(s)))
             {


### PR DESCRIPTION
Add support for log file format as written by markdownlint-cli 0.22.0.

Fixes #104 