### PR TITLE
Migrate deprecated FxCopAnalyzer to .Net Analyser

### DIFF
--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Core">
@@ -29,10 +30,9 @@
     <PackageReference Include="Cake.Issues">
       <Version>0.9.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.2</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add *AllEnabledByDefault*
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.