### PR TITLE
(GH-165) Add support for markdownlint-cli JSON format

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,12 +9,13 @@ The [Cake.Issues.Markdownlint addin] provides the following features.
 
 * Reads warnings from [Markdownlint] logfiles.
 * Provides URLs for all issues.
-* Support for custom URL resolving using the [MarkdownlintAddRuleUrlResolver] alias.
+* Support for custom URL resolving using the [MarkdownlintAddRuleUrlResolver] alias (except for [MarkdownlintCliJsonLogFileFormat]).
 
 # Supported log file formats
 
 * [MarkdownlintLogFileFormat] alias for reading issues from [Markdownlint] output generated with `options.resultVersion` set to 1.
 * [MarkdownlintCliLogFileFormat] alias for reading issues from [markdownlint-cli] log files.
+* [MarkdownlintCliJsonLogFileFormat] alias for reading issues from [markdownlint-cli] log files created with the `--json` parameter.
 
   :::{.alert .alert-info}
   [markdownlint-cli] can be run with the [Cake.Markdownlint] addin.
@@ -42,7 +43,7 @@ The [Cake.Issues.Markdownlint addin] provides the following features.
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Priority`                 | Always [IssuePriority.Warning]          |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.PriorityName`             | Always `Warning`                        |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Rule`                     |                                         |
-| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.RuleUrl`                  | Support for custom rules can be added through a custom [MarkdownlintAddRuleUrlResolver] |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.RuleUrl`                  | Support for custom rules can be added through a custom [MarkdownlintAddRuleUrlResolver] except for [MarkdownlintCliJsonLogFileFormat] |
 
 [Cake.Issues.Markdownlint addin]: https://www.nuget.org/packages/Cake.Issues.Markdownlint
 [Markdownlint]: https://github.com/DavidAnson/markdownlint
@@ -51,4 +52,5 @@ The [Cake.Issues.Markdownlint addin] provides the following features.
 [MarkdownlintAddRuleUrlResolver]: ../../../api/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases/2EE35F55
 [MarkdownlintLogFileFormat]: ../../../api/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases/EBFF674A
 [MarkdownlintCliLogFileFormat]: ../../../api/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases/B518F49E
+[MarkdownlintCliJsonLogFileFormat]: ../../../api/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases/36DE6F5F
 [IssuePriority.Warning]: ../../../api/Cake.Issues/IssuePriority/7A0CE07F

--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -17,12 +17,20 @@
     <CodeAnalysisRuleSet>..\Cake.Issues.Markdownlint.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\empty.json" />
+    <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\MD013.json" />
+    <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\MD025.json" />
+    <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\MD034.json" />
     <None Remove="Testfiles\MarkdownlintCliLogFileFormat\markdownlint-cli-0.22.0.log" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Issues.Markdownlint\Cake.Issues.Markdownlint.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\empty.json" />
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\MD013.json" />
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\MD025.json" />
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\MD034.json" />
     <EmbeddedResource Include="Testfiles\MarkdownlintCliLogFileFormat\markdownlint-cli-0.22.0.log" />
     <EmbeddedResource Include="Testfiles\MarkdownlintV1LogFileFormat\markdownlint.json" />
   </ItemGroup>

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
@@ -1,0 +1,111 @@
+﻿namespace Cake.Issues.Markdownlint.Tests.LogFileFormat
+{
+    using System;
+    using System.Linq;
+    using Cake.Issues.Markdownlint.LogFileFormat;
+    using Cake.Issues.Testing;
+    using Shouldly;
+    using Xunit;
+
+    public sealed class MarkdownlintCliJsonLogFileFormatTests
+    {
+        public sealed class TheCtor
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => new MarkdownlintCliJsonLogFileFormat(null));
+
+                // Then
+                result.IsArgumentNullException("log");
+            }
+        }
+
+        public sealed class TheReadIssuesMethod
+        {
+            [Fact]
+            public void Should_Read_Empty_File_Correct()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliJsonLogFileFormat>("empty.json");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Read_Issue_MD013_Correct()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliJsonLogFileFormat>("MD013.json");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                        "Line length: Expected: 80; Actual: 124",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/extending/fundamentals.md", 7, 7, 81, 125)
+                        .OfRule("MD013", new Uri("https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md013"))
+                        .WithPriority(IssuePriority.Warning));
+            }
+
+            [Fact]
+            public void Should_Read_Issue_MD025_Correct()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliJsonLogFileFormat>("MD025.json");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                        "Multiple top-level headings in the same document",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/extending/issue-provider/helper.md", 13)
+                        .OfRule("MD025", new Uri("https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md025"))
+                        .WithPriority(IssuePriority.Warning));
+            }
+
+            [Fact]
+            public void Should_Read_Issue_MD034_Correct()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliJsonLogFileFormat>("MD034.json");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                        "Bare URL used",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/report-formats/sarif/release-notes.md", 139, 139, 6, 74)
+                        .OfRule("MD034", new Uri("https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md034"))
+                        .WithPriority(IssuePriority.Warning));
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD013.json
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD013.json
@@ -1,0 +1,19 @@
+[
+  {
+    "fileName": "docs/extending/fundamentals.md",
+    "lineNumber": 7,
+    "ruleNames": [
+      "MD013",
+      "line-length"
+    ],
+    "ruleDescription": "Line length",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md013",
+    "errorDetail": "Expected: 80; Actual: 124",
+    "errorContext": null,
+    "errorRange": [
+      81,
+      44
+    ],
+    "fixInfo": null
+  }
+]

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD025.json
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD025.json
@@ -1,0 +1,17 @@
+[
+  {
+    "fileName": "docs/extending/issue-provider/helper.md",
+    "lineNumber": 13,
+    "ruleNames": [
+      "MD025",
+      "single-title",
+      "single-h1"
+    ],
+    "ruleDescription": "Multiple top-level headings in the same document",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md025",
+    "errorDetail": null,
+    "errorContext": "# File linking",
+    "errorRange": null,
+    "fixInfo": null
+  }
+]

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD034.json
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/MD034.json
@@ -1,0 +1,23 @@
+[
+  {
+    "fileName": "docs/report-formats/sarif/release-notes.md",
+    "lineNumber": 139,
+    "ruleNames": [
+      "MD034",
+      "no-bare-urls"
+    ],
+    "ruleDescription": "Bare URL used",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md034",
+    "errorDetail": null,
+    "errorContext": "https://github.com/cake-contri...",
+    "errorRange": [
+      6,
+      68
+    ],
+    "fixInfo": {
+      "editColumn": 6,
+      "deleteCount": 68,
+      "insertText": "<https://github.com/cake-contrib/Cake.Issues.Reporting.Sarif/issues/3>"
+    }
+  }
+]

--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
@@ -1,0 +1,122 @@
+﻿namespace Cake.Issues.Markdownlint.LogFileFormat
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Runtime.Serialization.Json;
+    using Cake.Core.Diagnostics;
+
+    /// <summary>
+    /// Logfile format as written by markdownlint-cli with <c>--json</c> parameter.
+    /// </summary>
+    internal class MarkdownlintCliJsonLogFileFormat : BaseMarkdownlintLogFileFormat
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownlintCliJsonLogFileFormat"/> class.
+        /// </summary>
+        /// <param name="log">The Cake log instance.</param>
+        public MarkdownlintCliJsonLogFileFormat(ICakeLog log)
+            : base(log)
+        {
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<IIssue> ReadIssues(
+            MarkdownlintIssuesProvider issueProvider,
+            IRepositorySettings repositorySettings,
+            MarkdownlintIssuesSettings markdownlintIssuesSettings)
+        {
+            issueProvider.NotNull(nameof(issueProvider));
+            repositorySettings.NotNull(nameof(repositorySettings));
+            markdownlintIssuesSettings.NotNull(nameof(markdownlintIssuesSettings));
+
+            if (!markdownlintIssuesSettings.LogFileContent.Any())
+            {
+                return new List<IIssue>();
+            }
+
+            IEnumerable<LogFileEntry> logFileEntries = null;
+            using (var ms = new MemoryStream(markdownlintIssuesSettings.LogFileContent.ToStringUsingEncoding(true).ToByteArray()))
+            {
+                var jsonSerializer = new DataContractJsonSerializer(typeof(LogFileEntry[]));
+                logFileEntries = jsonSerializer.ReadObject(ms) as LogFileEntry[];
+            }
+
+            if (logFileEntries == null)
+            {
+                return new List<IIssue>();
+            }
+
+            return logFileEntries.Select(x => GetIssue(x, issueProvider));
+        }
+
+        /// <summary>
+        /// Returns the issue for a message from the log file.
+        /// </summary>
+        /// <param name="logFileEntry">Issue reported by markdownlint.</param>
+        /// <param name="issueProvider">Issue provider instance.</param>
+        /// <returns>Issue instance.</returns>
+        private static IIssue GetIssue(
+            LogFileEntry logFileEntry,
+            MarkdownlintIssuesProvider issueProvider)
+        {
+            var message = logFileEntry.ruleDescription;
+
+            if (!string.IsNullOrEmpty(logFileEntry.errorDetail))
+            {
+                message += $": {logFileEntry.errorDetail}";
+            }
+
+            return
+                IssueBuilder
+                    .NewIssue(message, issueProvider)
+                    .InFile(
+                        logFileEntry.fileName,
+                        logFileEntry.lineNumber,
+                        logFileEntry.errorRange != null ? logFileEntry.lineNumber : null,
+                        logFileEntry.errorRange != null ? logFileEntry.errorRange[0] : null,
+                        logFileEntry.errorRange != null ? logFileEntry.errorRange[0] + logFileEntry.errorRange[1] : null)
+                    .WithPriority(IssuePriority.Warning)
+                    .OfRule(logFileEntry.ruleNames.First(), new Uri(logFileEntry.ruleInformation))
+                    .Create();
+        }
+
+#pragma warning disable SA1307 // Accessible fields must begin with upper-case letter
+#pragma warning disable SA1401 // Fields must be private
+#pragma warning disable CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
+
+        [DataContract]
+        private class LogFileEntry
+        {
+            [DataMember]
+            public string fileName;
+
+            [DataMember]
+            public int lineNumber;
+
+            [DataMember]
+            public string[] ruleNames;
+
+            [DataMember]
+            public string ruleDescription;
+
+            [DataMember]
+            public string ruleInformation;
+
+            [DataMember]
+            public string errorDetail;
+
+            [DataMember]
+            public string errorContext;
+
+            [DataMember]
+            public int[] errorRange;
+        }
+
+#pragma warning restore SA1401 // Fields must be private
+#pragma warning restore SA1307 // Accessible fields must begin with upper-case letter
+#pragma warning restore CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
+    }
+}

--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.MarkdownlintCliJsonLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.MarkdownlintCliJsonLogFileFormat.cs
@@ -1,0 +1,27 @@
+﻿namespace Cake.Issues.Markdownlint
+{
+    using Cake.Core;
+    using Cake.Core.Annotations;
+    using Cake.Issues.Markdownlint.LogFileFormat;
+
+    /// <summary>
+    /// Provider for issues reported my markdownlint-cli with <c>--json</c> parameter.
+    /// </summary>
+    public static partial class MarkdownlintIssuesAliases
+    {
+        /// <summary>
+        /// Gets an instance for the log format as written by markdownlint-cli with <c>--json</c> parameter.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>Instance for the Markdownlint log format.</returns>
+        [CakePropertyAlias]
+        [CakeAliasCategory(IssuesAliasConstants.IssueProviderCakeAliasCategory)]
+        public static BaseMarkdownlintLogFileFormat MarkdownlintCliJsonLogFileFormat(
+            this ICakeContext context)
+        {
+            context.NotNull(nameof(context));
+
+            return new MarkdownlintCliJsonLogFileFormat(context.Log);
+        }
+    }
+}


### PR DESCRIPTION
Add support for markdownlint-cli format writting using `--json` switch

Fixes #165 