### PR TITLE
(GH-168) markdownlint-cli JSON: Support absolute file paths

### DIFF
--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -17,6 +17,7 @@
     <CodeAnalysisRuleSet>..\Cake.Issues.Markdownlint.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\AbsoluteFilePath.json" />
     <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\empty.json" />
     <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\MD013.json" />
     <None Remove="Testfiles\MarkdownlintCliJsonLogFileFormat\MD025.json" />
@@ -27,6 +28,7 @@
     <ProjectReference Include="..\Cake.Issues.Markdownlint\Cake.Issues.Markdownlint.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\AbsoluteFilePath.json" />
     <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\empty.json" />
     <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\MD013.json" />
     <EmbeddedResource Include="Testfiles\MarkdownlintCliJsonLogFileFormat\MD025.json" />

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
@@ -106,6 +106,32 @@
                         .OfRule("MD034", new Uri("https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md034"))
                         .WithPriority(IssuePriority.Warning));
             }
+
+            [Fact]
+            public void Should_Read_Issue_With_Absolute_Path_Correct()
+            {
+                // Given
+                var fixture =
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliJsonLogFileFormat>("AbsoluteFilePath.json")
+                    {
+                        ReadIssuesSettings = new ReadIssuesSettings("/markdown"),
+                    };
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                        "Headings should be surrounded by blank lines: Expected: 1; Actual: 0; Below",
+                        "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                        "markdownlint")
+                        .InFile("docs/input/index.md", 4)
+                        .OfRule("MD022", new Uri("https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md022"))
+                        .WithPriority(IssuePriority.Warning));
+            }
         }
     }
 }

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/AbsoluteFilePath.json
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliJsonLogFileFormat/AbsoluteFilePath.json
@@ -1,0 +1,20 @@
+[
+  {
+    "fileName": "/markdown/docs/input/index.md",
+    "lineNumber": 4,
+    "ruleNames": [
+      "MD022",
+      "blanks-around-headings",
+      "blanks-around-headers"
+    ],
+    "ruleDescription": "Headings should be surrounded by blank lines",
+    "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md022",
+    "errorDetail": "Expected: 1; Actual: 0; Below",
+    "errorContext": "# Foo",
+    "errorRange": null,
+    "fixInfo": {
+      "lineNumber": 5,
+      "insertText": "\n"
+    }
+  }
+] 


### PR DESCRIPTION
Support absolute file paths for markdownlint-cli JSON format

Fixes #168 