### PR TITLE
(GH-92) Ignore files outside of repository root

### DIFF
--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
@@ -43,7 +43,10 @@
             {
                 // Given
                 var fixture =
-                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.8.1.log");
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.8.1.log")
+                    {
+                        ReadIssuesSettings = new ReadIssuesSettings("C:/Git/Test/Cake.Prca"),
+                    };
 
                 // When
                 var issues = fixture.ReadIssues().ToList();
@@ -129,7 +132,10 @@
             {
                 // Given
                 var fixture =
-                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.10.0.log");
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.10.0.log")
+                    {
+                        ReadIssuesSettings = new ReadIssuesSettings("C:/Git/Test/Cake.Prca"),
+                    };
 
                 // When
                 var issues = fixture.ReadIssues().ToList();
@@ -215,7 +221,10 @@
             {
                 // Given
                 var fixture =
-                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.19.0.log");
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.19.0.log")
+                    {
+                        ReadIssuesSettings = new ReadIssuesSettings("C:/Git/Test/Cake.Prca"),
+                    };
 
                 // When
                 var issues = fixture.ReadIssues().ToList();
@@ -310,7 +319,10 @@
             {
                 // Given
                 var fixture =
-                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.22.0.log");
+                    new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.22.0.log")
+                    {
+                        ReadIssuesSettings = new ReadIssuesSettings("C:/Git/Test/Cake.Prca"),
+                    };
 
                 // When
                 var issues = fixture.ReadIssues().ToList();

--- a/src/Cake.Issues.Markdownlint/BaseMarkdownlintLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/BaseMarkdownlintLogFileFormat.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Issues.Markdownlint
 {
+    using System;
     using Cake.Core.Diagnostics;
 
     /// <summary>
@@ -14,6 +15,88 @@
         protected BaseMarkdownlintLogFileFormat(ICakeLog log)
             : base(log)
         {
+        }
+
+        /// <summary>
+        /// Validates a file path.
+        /// </summary>
+        /// <param name="filePath">Full file path.</param>
+        /// <param name="repositorySettings">Repository settings.</param>
+        /// <returns>Tuple containing a value if validation was successful, and file path relative to repository root.</returns>
+        protected (bool Valid, string FilePath) ValidateFilePath(string filePath, IRepositorySettings repositorySettings)
+        {
+            filePath.NotNullOrWhiteSpace(nameof(filePath));
+            repositorySettings.NotNull(nameof(repositorySettings));
+
+            // Ignore files from outside the repository.
+            if (!this.CheckIfFileIsInRepository(filePath, repositorySettings))
+            {
+                return (false, string.Empty);
+            }
+
+            // Make path relative to repository root.
+            filePath = this.MakeFilePathRelativeToRepositoryRoot(filePath, repositorySettings);
+
+            // Remove leading directory separator.
+            filePath = this.RemoveLeadingDirectorySeparator(filePath);
+
+            return (true, filePath);
+        }
+
+        /// <summary>
+        /// Checks if a file is part of the repository.
+        /// </summary>
+        /// <param name="filePath">Full file path.</param>
+        /// <param name="repositorySettings">Repository settings.</param>
+        /// <returns>True if file is in repository, false otherwise.</returns>
+        protected bool CheckIfFileIsInRepository(string filePath, IRepositorySettings repositorySettings)
+        {
+            filePath.NotNullOrWhiteSpace(nameof(filePath));
+            repositorySettings.NotNull(nameof(repositorySettings));
+
+            if (!filePath.IsSubpathOf(repositorySettings.RepositoryRoot.FullPath))
+            {
+                this.Log.Warning(
+                    "Ignored issue for file '{0}' since it is outside the repository folder at {1}.",
+                    filePath,
+                    repositorySettings.RepositoryRoot);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Make path relative to repository root.
+        /// </summary>
+        /// <param name="filePath">Full file path.</param>
+        /// <param name="repositorySettings">Repository settings.</param>
+        /// <returns>File path relative to the repository root.</returns>
+        protected string MakeFilePathRelativeToRepositoryRoot(string filePath, IRepositorySettings repositorySettings)
+        {
+            filePath.NotNullOrWhiteSpace(nameof(filePath));
+            repositorySettings.NotNull(nameof(repositorySettings));
+
+            return filePath.Substring(repositorySettings.RepositoryRoot.FullPath.Length);
+        }
+
+        /// <summary>
+        /// Remove the leading directory separator from a file path.
+        /// </summary>
+        /// <param name="filePath">Full file path.</param>
+        /// <returns>File path without leading directory separator.</returns>
+        protected string RemoveLeadingDirectorySeparator(string filePath)
+        {
+            filePath.NotNullOrWhiteSpace(nameof(filePath));
+
+            if (filePath.StartsWith("\\", StringComparison.Ordinal) ||
+                filePath.StartsWith("/", StringComparison.Ordinal))
+            {
+                return filePath[1..];
+            }
+
+            return filePath;
         }
     }
 }

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
@@ -73,18 +73,15 @@
             IRepositorySettings repositorySettings,
             out string fileName)
         {
-            fileName = values["filePath"].Value;
+            values.NotNull(nameof(values));
+            repositorySettings.NotNull(nameof(repositorySettings));
 
-            // Make path relative to repository root.
-            fileName = fileName.Substring(repositorySettings.RepositoryRoot.FullPath.Length);
+            var filePath = values["filePath"].Value;
 
-            // Remove leading directory separator.
-            if (fileName.StartsWith("/"))
-            {
-                fileName = fileName.Substring(1);
-            }
-
-            return true;
+            // Validate file path and make relative to repository root.
+            bool result;
+            (result, fileName) = this.ValidateFilePath(filePath, repositorySettings);
+            return result;
         }
     }
 }


### PR DESCRIPTION
Improve reading of file path for markdownlint-cli format.

With previous versions it was possible to read issues from outside the repository directory (as done in test cases), but determination for relative file path was based on the length of repository root folder. With new implementation issues from outside the repository root are ignored. 

Can be simplified once cake-contrib/Cake.Issues#281 has been merged and released.

Fixes #92 