### PR TITLE
Update Dependabot configuration to ignore Cake 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,10 @@ updates:
   ignore:
   - dependency-name: Cake.Core
     versions:
-    - "> 1.0.0, < 2"
+    - "(,3.0)"
   - dependency-name: Cake.Testing
     versions:
-    - "> 1.0.0, < 2"
+    - "(,3.0)"
   - dependency-name: Cake.Issues
     versions:
     - "> 1.0.0, < 2"


### PR DESCRIPTION
Update Dependabot configuration to ignore Cake 2.x